### PR TITLE
Support setting Threshold via SSM leveraging context

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ handler
   .use(
     ssm({
       fetchData: {
+        // the keys (`recaptchaSecret` and `recaptchaThreshold`) are the keys picked up in `context` by `reCAPTCHA()`, if specified
         recaptchaSecret: "/dev/recaptcha/secret",
+        recaptchaThreshold: "/dev/recaptcha/threshold", // defaults to 0.8 if not specified
       },
       setToContext: true,
     })
@@ -150,7 +152,7 @@ With `secret`you can load your secret key from an `.env` file or env parameters 
 | Prop   |      Type      |  Description |
 |----------|:--------:|------------|
 | **secret** | string | Secret key from the reCAPTCHA admin. Highly recommend to use System Setting Manager.|
-| threshold | number | Default: `0.8`  reCAPTCHA v3 returns a score (1.0 is very likely a good interaction, 0.0 is very likely a bot). Based on the score, you can take variable action in the context of your site.  |
+| threshold | number | Default: `0.8`  reCAPTCHA v3 returns a score (1.0 is very likely a good interaction, 0.0 is very likely a bot). Based on the score, you can take variable action in the context of your site. (Supports System Setting Manager via context)  |
 | useIp | boolean |    Default `false` Optional. The user's IP address. |
 
 ### TODO

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -66,6 +66,13 @@ async function post({ url, params }: IPost) {
   });
 }
 
+function checkIfNumeric (num: any) {
+  if (!['number', 'string'].includes(typeof num)) {
+    return false;
+  }
+  return `${num}` === Number(num).toString();
+}
+
 const defaults = { threshold: 0.8, secret: "", useIp: false };
 
 const reCAPTCHA = ({ ...opts }: IReCaptcha) => {
@@ -80,6 +87,7 @@ const reCAPTCHA = ({ ...opts }: IReCaptcha) => {
     const secret = options.secret.length
       ? options.secret
       : request.context.recaptchaSecret;
+    const threshold = checkIfNumeric(request.context.recaptchaThreshold) ? Number(request.context.recaptchaThreshold) : options.threshold;
     const token = request.event.body.token;
     const remoteIP = request.event.headers["x-forwarded-for"];
 
@@ -100,7 +108,7 @@ const reCAPTCHA = ({ ...opts }: IReCaptcha) => {
         let response = JSON.parse(res);
         console.info("reCAPTCHA: ", res);
         if (response.success) {
-          if (response.score >= options.threshold) {
+          if (response.score >= threshold) {
             result = {
               success: response.success,
               challenge_ts: response.challenge_ts,


### PR DESCRIPTION
Recently, I wanted to add querying the reCAPTCHA threshold via SSM in AWS. Google recommends starting with your threshold at 0.5 and adjusting it based on the traffic received as logged in the ReCAPTCHA admin portal.

In order to make it easy to modify the threshold with other application parameters, I wanted to pull this from SSM.

Unfortunatley, even with Node14.x runtime in Lambda, we still cannot use top-level await to resolve this parameter via traditional methods outside of the asynchronous function handler, and therefore have no way to resolve this promise and pass the threshold to the reCAPTCHA middleware (as this exists outside the context of the function callback).

This PR, similar to pulling secrets from context, also looks for the threshold to be set on context. Since "0" and 0 are valid entries, a new function "checkIfNumeric" was added to make sure whatever value is set in context is an actual number, or a string representation of a number.

The README has been updated to reflect this new feature.

As per my first commit message, I did test the function I added so the behaviour would be predictable, but I did not see any tests or test library setup for this library.

Here is the passing test:

```javascript
describe('checkIfNumeric', () => {
  it('works', () => {
    const mock = [
      { input: undefined, output: false },
      { input: null, output: false },
      { input: true, output: false },
      { input: false, output: false },
      { input: "", output: false },
      { input: {}, output: false },
      { input: [], output: false },
      { input: 0, output: true },
      { input: "0", output: true },
      { input: 1, output: true },
      { input: "1", output: true },
      { input: 0.2, output: true },
    ];
    mock.forEach(({input, output}) => {
      expect(checkIfNumeric(input)).toBe(output);
    })
  })
})
```